### PR TITLE
PlayModeEditReminder.cs: fixed a warning on line 18

### DIFF
--- a/Tools/Editor/Play Mode Edit Reminder/PlayModeEditReminder.cs
+++ b/Tools/Editor/Play Mode Edit Reminder/PlayModeEditReminder.cs
@@ -15,7 +15,7 @@ public static class PlayModeEditReminder
 
     static PlayModeEditReminder()
     {
-        SceneView.onSceneGUIDelegate += OnSceneGUI;
+        SceneView.duringSceneGui += OnSceneGUI;
     }
     static void OnSceneGUI(SceneView view)
     {


### PR DESCRIPTION
SceneView.onSceneGUIDelegate has been deprecated as of Unity 2019.1